### PR TITLE
Add v4 scaffold with edge, cloud and MLOps folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # AI Digital Twin Toolkit
 
 Welcome to the AI Digital Twin Toolkit repository, an advanced Python framework designed to facilitate the development and implementation of digital twin technologies with a focus on artificial intelligence integration. This toolkit serves as a practical extension to the "Digital Twin Guide," offering readers and developers alike a hands-on approach to creating digital twins that leverage AI for enhanced simulation, prediction, and operation across various domains.
+This fourth edition focuses on factory-of-the-future integration. New directories (/edge, /cloud, /mlops) organize the toolkit around Jetson-powered robots, cloud twins, and MLOps pipelines. See `docs/book` for draft chapters.
+
 
 ## Table of Contents
 
 - Getting Started
+
 - Prerequisites
 - Installation
 - Usage

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -1,0 +1,1 @@
+# Cloud Integrations

--- a/docs/book/README.md
+++ b/docs/book/README.md
@@ -1,0 +1,1 @@
+# Digital Twin Playbook

--- a/docs/book/chapter1.md
+++ b/docs/book/chapter1.md
@@ -1,0 +1,9 @@
+# Prelude—The Robotics Tipping Point
+
+This introductory chapter sets the stage for the fourth edition of the Digital‑Twin Toolkit. It frames the rapid acceleration in robotics and industrial AI that now enables factory‑floor autonomy. Readers will revisit the original DevOps pipeline and see how narrative elements evolved into a technical playbook. Key motivations include bridging OT and IT practices and preparing for adaptive‑cloud operations.
+
+*Pipeline Exercise*: Clone the repository and explore the new `/edge`, `/cloud`, and `/mlops` folders.
+
+*Metric to Watch*: Percentage of factory processes instrumented with edge telemetry.
+
+*Anecdote*: Legend tells of an engineer who coaxed a dormant robot back to life by singing a systems diagram aloud—proof that art and code need not be rivals.

--- a/docs/book/chapter2.md
+++ b/docs/book/chapter2.md
@@ -1,0 +1,9 @@
+# Landscape 2025: Platforms, Standards, Talent
+
+Chapter two surveys the evolving industrial‑AI ecosystem. Adoption metrics reveal that less than one‑third of manufacturers run AI at scale, underscoring the need for robust integration patterns. Major vendors now support digital‑twin platforms—Azure Digital Twins and AWS TwinMaker—and offer simplified deployment of AI services like NVIDIA NIM. The chapter also highlights the agile‑hardware movement as a cultural shift toward rapid iteration.
+
+*Pipeline Exercise*: Generate an industry snapshot report by running `python tools/collect_stats.py` (placeholder script).
+
+*Metric to Watch*: Ratio of physical assets represented in the cloud twin.
+
+*Anecdote*: A veteran operator once nicknamed her line of robots the "whispering choir" because small calibration tweaks could turn cacophony into harmony.

--- a/docs/research_prompt.yaml
+++ b/docs/research_prompt.yaml
@@ -1,0 +1,43 @@
+# Research instructions for Codex or other agents
+goal: "Collect implementation assets for Digital-Twin Toolkit v4"
+deliverables:
+  - comparative_matrix.csv
+  - sample_code/*.py
+  - architecture_diagram.drawio
+  - literature_summary.md
+
+tasks:
+  - id: survey_platforms
+    description: |
+      Scrape official docs & blogs for
+      {Azure Digital Twins, AWS TwinMaker, Nvidia NIM, Isaac SIM, KubeEdge, ROS 2-OPC UA bridges}
+    output: comparative_matrix.csv
+
+  - id: edge_robot_prototype
+    description: |
+      Generate Jetson-Nano Dockerfile + ROS 2 navigation stack example.
+    depends_on: survey_platforms
+    output: sample_code/jetson_nav.dockerfile
+
+  - id: twin_schema
+    description: |
+      Convert ISA-95 equipment hierarchy Excel to Azure Digital Twins DTDL.
+    refs:
+      - https://learn.microsoft.com/azure/digital-twins/how-to-ingest-opcua-data
+    output: sample_code/isa95_to_dtdl.py
+
+  - id: nim_serving
+    description: |
+      Produce Helm chart that deploys a NIM LLM micro-service and registers endpoint in Kubeflow.
+    output: sample_code/nim_chart/
+
+  - id: write_summary
+    description: |
+      Auto-summarize each source (250 w max) with citation links.
+    depends_on: [survey_platforms, twin_schema]
+    output: literature_summary.md
+
+agent_instructions:
+  - prefer_official_docs: true
+  - cite_everything: true
+  - use_python_linting: true

--- a/edge/Dockerfile.jetson
+++ b/edge/Dockerfile.jetson
@@ -1,0 +1,8 @@
+FROM nvcr.io/nvidia/l4t-base:r32.7.1
+
+# Install ROS 2 and dependencies (placeholder)
+RUN apt-get update && \
+    apt-get install -y ros-foxy-desktop && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["/bin/bash"]

--- a/edge/README.md
+++ b/edge/README.md
@@ -1,0 +1,1 @@
+# Edge Toolkit

--- a/edge/jetson_image_build.sh
+++ b/edge/jetson_image_build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Jetson Nano SD card image build script
+# Reference: https://developer.nvidia.com/embedded/learn/get-started-jetson-nano-devkit
+
+set -e
+
+IMAGE_URL="https://developer.download.nvidia.com/embedded/L4T/r32.7.1/jetson-nano-sd-card-image.zip"
+IMAGE_ZIP="jetson-nano-sd-card-image.zip"
+IMAGE_DIR="jetson-nano-image"
+
+mkdir -p "$IMAGE_DIR"
+cd "$IMAGE_DIR"
+
+if [ ! -f "$IMAGE_ZIP" ]; then
+    echo "Downloading image from $IMAGE_URL"
+    curl -L -o "$IMAGE_ZIP" "$IMAGE_URL"
+fi
+
+unzip -o "$IMAGE_ZIP"
+
+IMG_FILE=$(ls *.img | head -n 1)
+
+echo "Writing $IMG_FILE to /dev/sdX..." 
+# Example dd command, replace /dev/sdX with your SD card device
+# sudo dd if="$IMG_FILE" of=/dev/sdX bs=1M status=progress
+
+echo "Image ready."

--- a/mlops/README.md
+++ b/mlops/README.md
@@ -1,0 +1,1 @@
+# MLOps Pipelines

--- a/mlops/kubeflow_pipeline.py
+++ b/mlops/kubeflow_pipeline.py
@@ -1,0 +1,8 @@
+"""Placeholder Kubeflow pipeline script for MLOps stage."""
+
+def build_pipeline():
+    # TODO: Define Kubeflow pipeline components
+    pass
+
+if __name__ == "__main__":
+    build_pipeline()


### PR DESCRIPTION
## Summary
- start fourth edition structure with new `edge`, `cloud`, and `mlops` folders
- document research prompt for agents
- add Jetson image build helper script and Jetson Dockerfile
- create initial chapters for the book
- update README with note about the new focus

## Testing
- `python -m unittest discover -s tests` *(fails: Start directory is not importable)*

------
https://chatgpt.com/codex/tasks/task_e_685a8147187483218d9f1d7486b9a593